### PR TITLE
Hotfix - string encoding / Release v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased](https://github.com/packlink-dev/ecommerce_module_core/compare/master...dev)
 
+## [v1.5.2](https://github.com/packlink-dev/ecommerce_module_core/compare/v1.5.1...v1.5.2) - 2019-12-04
+### Changed
+- Replaced `substr` with `mb_substring` to prevent cutting the string in the middle of the special unicode character.
+
 ## [v1.5.1](https://github.com/packlink-dev/ecommerce_module_core/compare/v1.5.0...v1.5.1) - 2019-11-28
 ### Changed
-- `AjaxService.js:call` method now removes the protocol from the URL in order to use the current page's protocol/.
+- `AjaxService.js:call` method now removes the protocol from the URL in order to use the current page's protocol.
 
 ## [v1.5.0](https://github.com/packlink-dev/ecommerce_module_core/compare/v1.4.1...v1.5.0) - 2019-11-18
 ### Added

--- a/src/BusinessLogic/Http/DTO/Draft.php
+++ b/src/BusinessLogic/Http/DTO/Draft.php
@@ -234,6 +234,6 @@ class Draft extends BaseDto
 
         $content = implode(', ', $this->content);
 
-        return substr(str_replace($forbiddenCharacters, '', $content), 0, 60);
+        return mb_substr(str_replace($forbiddenCharacters, '', $content), 0, 60);
     }
 }

--- a/src/Infrastructure/Http/CurlHttpClient.php
+++ b/src/Infrastructure/Http/CurlHttpClient.php
@@ -184,8 +184,8 @@ class CurlHttpClient extends HttpClient
     {
         $delimiter = "\r\n\r\n";
         $needle = 'HTTP/1.1 100';
-        if (strpos($response, $needle) === 0) {
-            return substr($response, strpos($response, $delimiter) + 4);
+        if (mb_strpos($response, $needle) === 0) {
+            return mb_substr($response, mb_strpos($response, $delimiter) + 4);
         }
 
         return $response;
@@ -335,7 +335,7 @@ class CurlHttpClient extends HttpClient
     {
         $headers = array();
         $headersBodyDelimiter = "\r\n\r\n";
-        $headerText = substr($response, 0, strpos($response, $headersBodyDelimiter));
+        $headerText = mb_substr($response, 0, mb_strpos($response, $headersBodyDelimiter));
         $headersDelimiter = "\r\n";
 
         foreach (explode($headersDelimiter, $headerText) as $i => $line) {
@@ -362,7 +362,7 @@ class CurlHttpClient extends HttpClient
         $headersBodyDelimiter = "\r\n\r\n";
         $bodyStartingPositionOffset = 4; // number of special signs in delimiter;
 
-        return substr($response, strpos($response, $headersBodyDelimiter) + $bodyStartingPositionOffset);
+        return mb_substr($response, mb_strpos($response, $headersBodyDelimiter) + $bodyStartingPositionOffset);
     }
 
     /**
@@ -417,7 +417,7 @@ class CurlHttpClient extends HttpClient
         $domain = parse_url($url, PHP_URL_HOST);
         $options = $this->getAdditionalOptions($domain);
         if (!empty($options[self::SWITCH_PROTOCOL])) {
-            if (strpos($url, 'http:') === 0) {
+            if (mb_strpos($url, 'http:') === 0) {
                 $url = str_replace('http:', 'https:', $url);
             } else {
                 $url = str_replace('https:', 'http:', $url);

--- a/tests/Infrastructure/Common/TestComponents/ORM/MemoryRepository.php
+++ b/tests/Infrastructure/Common/TestComponents/ORM/MemoryRepository.php
@@ -263,7 +263,7 @@ class MemoryRepository implements RepositoryInterface
 
                         // %SEARCH
                         if ($firstP === 0 && $firstP === $lastP) {
-                            return $position !== false && $position + strlen($b) === strlen($a);
+                            return $position !== false && $position + mb_strlen($b) === mb_strlen($a);
                         }
 
                         return false;


### PR DESCRIPTION
Replaced `substr` with `mb_substring` to prevent cutting the string in the middle of the special unicode character.

Please release `v1.5.2`