### PR TITLE
Optimize HttpClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased](https://github.com/packlink-dev/ecommerce_module_core/compare/master...dev)
+## [2.0.10](https://github.com/packlink-dev/ecommerce_module_core/compare/v2.0.9...v2.0.10)
 ### Added
 - Added configuration flag for async request progress callback usage (methods
 `Configuration::isAsyncRequestWithProgress` and `Configuration::setAsyncRequestWithProgress`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased](https://github.com/packlink-dev/ecommerce_module_core/compare/master...dev)
+### Added
+- Added configuration flag for async request progress callback usage (methods
+`Configuration::isAsyncRequestWithProgress` and `Configuration::setAsyncRequestWithProgress`)
+
+### Changed
+- Changed default timeout for async requests that utilize progress callback to be the same as for standard sync request.
+In this case progress callback is controlling request abort based on uploaded data so short timeout is undesirable.
 
 ## [2.0.9](https://github.com/packlink-dev/ecommerce_module_core/compare/v2.0.8...v2.0.9) - 2020-05-15
 ### Added

--- a/src/Infrastructure/Configuration/Configuration.php
+++ b/src/Infrastructure/Configuration/Configuration.php
@@ -39,6 +39,10 @@ abstract class Configuration extends Singleton
      */
     const ASYNC_CALL_METHOD = 'POST';
     /**
+     * Default asynchronous request timeout value in milliseconds when progress callback is used.
+     */
+    const DEFAULT_ASYNC_REQUEST_WITH_PROGRESS_TIMEOUT = 60000;
+    /**
      * System user context.
      *
      * @var string
@@ -438,7 +442,12 @@ abstract class Configuration extends Singleton
      */
     public function getAsyncRequestTimeout()
     {
-        return $this->getConfigValue('asyncRequestTimeout');
+        $configValue = $this->getConfigValue('asyncRequestTimeout');
+        if ($configValue || !$this->isAsyncRequestWithProgress()) {
+            return $configValue;
+        }
+
+        return static::DEFAULT_ASYNC_REQUEST_WITH_PROGRESS_TIMEOUT;
     }
 
     /**

--- a/src/Infrastructure/Configuration/Configuration.php
+++ b/src/Infrastructure/Configuration/Configuration.php
@@ -452,6 +452,26 @@ abstract class Configuration extends Singleton
     }
 
     /**
+     * Returns whether the async requests are aborted with progress callback (used in CurlHttpClient).
+     *
+     * @return bool TRUE if the async requests are aborted with progress callback; otherwise, FALSE.
+     */
+    public function isAsyncRequestWithProgress()
+    {
+        return (bool)$this->getConfigValue('asyncRequestWithProgress', false);
+    }
+
+    /**
+     * Sets flag for usage of progress callback abort mechanism inside CurlHttpClient
+     *
+     * @param bool $withProgress
+     */
+    public function setAsyncRequestWithProgress($withProgress)
+    {
+        $this->saveConfigValue('asyncRequestWithProgress', $withProgress);
+    }
+
+    /**
      * Gets configuration value for given name.
      *
      * @param string $name Name of the config parameter.

--- a/src/Infrastructure/Configuration/Configuration.php
+++ b/src/Infrastructure/Configuration/Configuration.php
@@ -39,10 +39,6 @@ abstract class Configuration extends Singleton
      */
     const ASYNC_CALL_METHOD = 'POST';
     /**
-     * Default asynchronous request timeout value in milliseconds when progress callback is used.
-     */
-    const DEFAULT_ASYNC_REQUEST_WITH_PROGRESS_TIMEOUT = 60000;
-    /**
      * System user context.
      *
      * @var string
@@ -442,12 +438,7 @@ abstract class Configuration extends Singleton
      */
     public function getAsyncRequestTimeout()
     {
-        $configValue = $this->getConfigValue('asyncRequestTimeout');
-        if ($configValue || !$this->isAsyncRequestWithProgress()) {
-            return $configValue;
-        }
-
-        return static::DEFAULT_ASYNC_REQUEST_WITH_PROGRESS_TIMEOUT;
+        return $this->getConfigValue('asyncRequestTimeout');
     }
 
     /**

--- a/src/Infrastructure/Http/CurlHttpClient.php
+++ b/src/Infrastructure/Http/CurlHttpClient.php
@@ -278,15 +278,13 @@ class CurlHttpClient extends HttpClient
     {
         // Always ensure the connection is fresh.
         $this->curlOptions[CURLOPT_FRESH_CONNECT] = true;
-        // Timeout super fast once connected, so it goes into async.
-        $asyncRequestTimeout = $this->getConfigService()->getAsyncRequestTimeout();
-        $this->curlOptions[CURLOPT_TIMEOUT_MS] = $asyncRequestTimeout ?: static::DEFAULT_ASYNC_REQUEST_TIMEOUT;
+        // Timeout super fast once connected, so it goes into async. Pay attention that fast timout is not desired when
+        // callback progress method is used for request aborting because request can go in timout before request
+        // upload finishes therefore making async requests less stable that it needs to be.
+        $this->curlOptions[CURLOPT_TIMEOUT_MS] =
+            $this->getConfigService()->getAsyncRequestTimeout() ?: static::DEFAULT_ASYNC_REQUEST_TIMEOUT;
 
         if ($this->getConfigService()->isAsyncRequestWithProgress()) {
-            // Use sync request timeout by default if progress callback mechanism is used for async request aborting.
-            // We do not need/want fast timeouts in this case because the abort mechanism relays on the amount of
-            // uploaded data.
-            $this->curlOptions[CURLOPT_TIMEOUT_MS] = $asyncRequestTimeout ?: static::DEFAULT_REQUEST_TIMEOUT;
             $this->curlOptions[CURLOPT_NOPROGRESS] = false;
             $this->curlOptions[CURLOPT_PROGRESSFUNCTION] = array($this, 'abortAfterAsyncRequestCallback');
         }

--- a/tests/Infrastructure/Http/CurlHttpClientTest.php
+++ b/tests/Infrastructure/Http/CurlHttpClientTest.php
@@ -2,7 +2,6 @@
 
 namespace Logeecom\Tests\Infrastructure\Http;
 
-use Logeecom\Infrastructure\Configuration\Configuration;
 use Logeecom\Infrastructure\Http\CurlHttpClient;
 use Logeecom\Infrastructure\Http\HttpClient;
 use Logeecom\Tests\Infrastructure\Common\BaseInfrastructureTestWithServices;
@@ -104,7 +103,7 @@ class CurlHttpClientTest extends BaseInfrastructureTestWithServices
         $this->httpClient->requestAsync('POST', 'test.url.com');
 
         $this->assertProgressCallback();
-        $this->assertCallTimeout(Configuration::DEFAULT_ASYNC_REQUEST_WITH_PROGRESS_TIMEOUT);
+        $this->assertCallTimeout(CurlHttpClient::DEFAULT_ASYNC_REQUEST_WITH_PROGRESS_TIMEOUT);
     }
 
     /**

--- a/tests/Infrastructure/Http/CurlHttpClientTest.php
+++ b/tests/Infrastructure/Http/CurlHttpClientTest.php
@@ -57,7 +57,7 @@ class CurlHttpClientTest extends BaseInfrastructureTestWithServices
     /**
      * Test an async call.
      */
-    public function testAsyncCall()
+    public function testDefaultAsyncCall()
     {
         $responses = array($this->getResponse(200));
 
@@ -78,13 +78,61 @@ class CurlHttpClientTest extends BaseInfrastructureTestWithServices
     /**
      * Test an async call with custom timeout.
      */
-    public function testAsyncCallDifferentTimeout()
+    public function testDefaultAsyncCallDifferentTimeout()
     {
         $responses = array($this->getResponse(200));
 
         $this->httpClient->setMockResponses($responses);
 
         $newTimeout = 200;
+        $this->shopConfig->setAsyncRequestTimeout($newTimeout);
+        $this->httpClient->requestAsync('POST', 'test.url.com');
+
+        $this->assertCallTimeout($newTimeout);
+    }
+
+    /**
+     * Test async call with progress callback
+     */
+    public function testAsyncCallWithProgressCallback()
+    {
+        $responses = array($this->getResponse(200));
+        $this->httpClient->setMockResponses($responses);
+
+        $this->shopConfig->setAsyncRequestWithProgress(true);
+        $this->httpClient->requestAsync('POST', 'test.url.com');
+
+        $this->assertProgressCallback();
+        $this->assertCallTimeout(CurlHttpClient::DEFAULT_REQUEST_TIMEOUT);
+    }
+
+    /**
+     * Test async call without progress callback
+     */
+    public function testAsyncCallWithoutProgressCallback()
+    {
+        $responses = array($this->getResponse(200));
+
+        $this->httpClient->setMockResponses($responses);
+
+        $this->shopConfig->setAsyncRequestWithProgress(false);
+        $this->httpClient->requestAsync('POST', 'test.url.com');
+
+        $this->assertProgressCallback(false);
+        $this->assertCallTimeout(CurlHttpClient::DEFAULT_ASYNC_REQUEST_TIMEOUT);
+    }
+
+    /**
+     * Test an async call with custom timeout and progress callback.
+     */
+    public function testDAsyncCallWithProgressCallbackDifferentTimeout()
+    {
+        $responses = array($this->getResponse(200));
+
+        $this->httpClient->setMockResponses($responses);
+
+        $newTimeout = 200;
+        $this->shopConfig->setAsyncRequestWithProgress(true);
         $this->shopConfig->setAsyncRequestTimeout($newTimeout);
         $this->httpClient->requestAsync('POST', 'test.url.com');
 
@@ -179,6 +227,43 @@ class CurlHttpClientTest extends BaseInfrastructureTestWithServices
             $timeout,
             $curlOptions[CURLOPT_TIMEOUT_MS],
             'Curl default timeout should be set for async call.'
+        );
+    }
+
+    private function assertProgressCallback($isOn = true)
+    {
+        $curlOptions = $this->httpClient->getCurlOptions();
+        $this->assertNotEmpty($curlOptions, 'Curl options should be set.');
+        if (!$isOn) {
+            $this->assertFalse(
+                isset($curlOptions[CURLOPT_NOPROGRESS]),
+                'Curl progress callback should not be set.'
+            );
+            $this->assertFalse(
+                isset($curlOptions[CURLOPT_PROGRESSFUNCTION]),
+                'Curl progress callback should not be set.'
+            );
+
+            return;
+        }
+
+
+        $this->assertTrue(
+            isset($curlOptions[CURLOPT_NOPROGRESS]),
+            'Curl progress callback should be set for async call.'
+        );
+        $this->assertFalse(
+            $curlOptions[CURLOPT_NOPROGRESS],
+            'Curl progress callback should be set for async call.'
+        );
+        $this->assertTrue(
+            isset($curlOptions[CURLOPT_PROGRESSFUNCTION]),
+            'Curl progress callback should be set for async call.'
+        );
+        $this->assertEquals(
+            array($this->httpClient, 'abortAfterAsyncRequestCallback'),
+            $curlOptions[CURLOPT_PROGRESSFUNCTION],
+            'Curl progress callback should be set for async call.'
         );
     }
 }

--- a/tests/Infrastructure/Http/CurlHttpClientTest.php
+++ b/tests/Infrastructure/Http/CurlHttpClientTest.php
@@ -2,6 +2,7 @@
 
 namespace Logeecom\Tests\Infrastructure\Http;
 
+use Logeecom\Infrastructure\Configuration\Configuration;
 use Logeecom\Infrastructure\Http\CurlHttpClient;
 use Logeecom\Infrastructure\Http\HttpClient;
 use Logeecom\Tests\Infrastructure\Common\BaseInfrastructureTestWithServices;
@@ -103,7 +104,7 @@ class CurlHttpClientTest extends BaseInfrastructureTestWithServices
         $this->httpClient->requestAsync('POST', 'test.url.com');
 
         $this->assertProgressCallback();
-        $this->assertCallTimeout(CurlHttpClient::DEFAULT_ASYNC_REQUEST_TIMEOUT);
+        $this->assertCallTimeout(Configuration::DEFAULT_ASYNC_REQUEST_WITH_PROGRESS_TIMEOUT);
     }
 
     /**

--- a/tests/Infrastructure/Http/CurlHttpClientTest.php
+++ b/tests/Infrastructure/Http/CurlHttpClientTest.php
@@ -103,7 +103,7 @@ class CurlHttpClientTest extends BaseInfrastructureTestWithServices
         $this->httpClient->requestAsync('POST', 'test.url.com');
 
         $this->assertProgressCallback();
-        $this->assertCallTimeout(CurlHttpClient::DEFAULT_REQUEST_TIMEOUT);
+        $this->assertCallTimeout(CurlHttpClient::DEFAULT_ASYNC_REQUEST_TIMEOUT);
     }
 
     /**


### PR DESCRIPTION
- Added configuration flag for async request progress callback usage (methods
`Configuration::isAsyncRequestWithProgress` and `Configuration::setAsyncRequestWithProgress`)
- Changed default timeout for async requests that utilize progress callback to be the same as for standard sync requests. In this case progress callback is controlling request abort based on uploaded data so short timeout is undesirable.

Please review and release a new version v2.0.10