### PR TITLE
Release version 3.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [3.3.5](https://github.com/packlink-dev/ecommerce_module_core/compare/v3.3.4...v3.3.5) - 2021-01-31
+### Added
+- Added a new configuration flag that specifies whether a given integration supports drop-off carriers or not. The default will be `true` and only integrations that do not support drop-off carriers should set this flag to `false`.
+### Changed
+- Fixed a frontend issue when adding/editing a shipping service on the module configuration page.
+
 ## [3.3.4](https://github.com/packlink-dev/ecommerce_module_core/compare/v3.3.3...v3.3.4) - 2021-11-30
 ### Changed
 - Updated the mechanism for fetching controller URLs on the frontend views.

--- a/src/BusinessLogic/Configuration.php
+++ b/src/BusinessLogic/Configuration.php
@@ -54,6 +54,16 @@ abstract class Configuration extends \Logeecom\Infrastructure\Configuration\Conf
     }
 
     /**
+     * Determines whether the drop-off shipping services are system supported.
+     *
+     * @return bool
+     */
+    public function dropOffShippingServicesSupported()
+    {
+        return true;
+    }
+
+    /**
      * Returns web-hook callback URL for current system.
      *
      * @return string Web-hook callback URL.

--- a/src/BusinessLogic/Resources/js/EditServiceController.js
+++ b/src/BusinessLogic/Resources/js/EditServiceController.js
@@ -328,16 +328,20 @@ if (!window.Packlink) {
             }
 
             for (let systemId in pricePolicyControllers) {
-                let fieldName = pricePolicyControllers[systemId].getExcludedFieldForValidation();
-                if (fieldName !== null) {
-                    excludedElementNames.push(fieldName);
+                if (pricePolicyControllers.hasOwnProperty(systemId)) {
+                    let fieldName = pricePolicyControllers[systemId].getExcludedFieldForValidation();
+                    if (fieldName !== null) {
+                        excludedElementNames.push(fieldName);
+                    }
                 }
             }
 
             if (validationService.validateForm(form, excludedElementNames) && validateMiconfiguredPolicies()) {
                 let pricingPolicies = [];
                 for (let systemId in pricePolicyControllers) {
-                    pricingPolicies = pricingPolicies.concat(pricePolicyControllers[systemId].getSystemPricingPolicies());
+                    if (pricePolicyControllers.hasOwnProperty(systemId)) {
+                        pricingPolicies = pricingPolicies.concat(pricePolicyControllers[systemId].getSystemPricingPolicies());
+                    }
                 }
 
                 serviceModel.activated = true;


### PR DESCRIPTION
### Added
- Added a new configuration flag that specifies whether a given integration supports drop-off carriers or not. The default will be `true` and only integrations that do not support drop-off carriers should set this flag to `false`.
### Changed
- Fixed a frontend issue when adding/editing a shipping service on the module configuration page.