### PR TITLE
Release version 3.3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased changes
 
+## [3.3.12](https://github.com/packlink-dev/ecommerce_module_core/compare/v3.3.11...v3.3.12) - 2023-01-31
+### Changed
+- In `DtoValidator` email is now trimmed before validation.
+- Changed Chrome version to latest in curl user agent.
+
 ## [3.3.11](https://github.com/packlink-dev/ecommerce_module_core/compare/v3.3.10...v3.3.11) - 2022-09-26
 ### Added
 - Added 'shipment.carrier.delivered' event to the list of valid events that are handled by webhook handler.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased changes
+
+## [3.3.11](https://github.com/packlink-dev/ecommerce_module_core/compare/v3.3.10...v3.3.11) - 2022-09-26
 ### Added
 - Added 'shipment.carrier.delivered' event to the list of valid events that are handled by webhook handler.
 

--- a/src/BusinessLogic/Utility/DtoValidator.php
+++ b/src/BusinessLogic/Utility/DtoValidator.php
@@ -18,7 +18,7 @@ class DtoValidator
      */
     public static function isEmailValid($email)
     {
-        return filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
+        return filter_var(trim($email), FILTER_VALIDATE_EMAIL) !== false;
     }
 
     /**

--- a/src/Infrastructure/Http/CurlHttpClient.php
+++ b/src/Infrastructure/Http/CurlHttpClient.php
@@ -234,7 +234,7 @@ class CurlHttpClient extends HttpClient
         $this->curlOptions[CURLOPT_SSL_VERIFYHOST] = static::SSL_STRICT_MODE;
         // Set default user agent, because for some shops if user agent is missing, request will not work.
         $this->curlOptions[CURLOPT_USERAGENT] =
-            'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 Safari/537.36';
+            'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.5249.91 Safari/537.36';
     }
 
     /**


### PR DESCRIPTION
**Changed**

- In `DtoValidator` email is now trimmed before validation.
- Changed Chrome version to latest in curl user agent.